### PR TITLE
feat(dizz): change text colour to white making it more readable

### DIFF
--- a/src/styles.ts
+++ b/src/styles.ts
@@ -33,7 +33,7 @@ export const Diff = styled.pre`
   margin: 0;
   padding: 16px;
   border-radius: 4px;
-  color: ${color('b70')};
+  color: ${color('white')};
   border: 1px solid ${color('black')};
   background-color: ${color('black')};
 `


### PR DESCRIPTION
 Hi @wcastand ,
   I was using dizz and realised the text colour wasn't so clear so i fiddled around and changed it to white. 

I can see why its B70 as it allows the diff red and blue to stand out more, but i think even with the change to white all of the text is clearer.

Let me know what you think ? :)

![image](https://user-images.githubusercontent.com/6556019/68207614-34beb900-ffc7-11e9-850c-4c1892744803.png)
